### PR TITLE
Include severity in all log callbacks

### DIFF
--- a/rtc_base/logging.cc
+++ b/rtc_base/logging.cc
@@ -82,7 +82,12 @@ CriticalSection g_log_crit;
 void LogSink::OnLogMessage(const std::string& msg,
                            LoggingSeverity severity,
                            const char* tag) {
-  OnLogMessage(tag + (": " + msg));
+  OnLogMessage(tag + (": " + msg), severity);
+}
+
+void LogSink::OnLogMessage(const std::string& msg,
+                           LoggingSeverity /* severity */) {
+  OnLogMessage(msg);
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -229,7 +234,7 @@ LogMessage::~LogMessage() {
 #if defined(WEBRTC_ANDROID)
       kv.first->OnLogMessage(str, severity_, tag_);
 #else
-      kv.first->OnLogMessage(str);
+      kv.first->OnLogMessage(str, severity_);
 #endif
     }
   }

--- a/rtc_base/logging.h
+++ b/rtc_base/logging.h
@@ -119,6 +119,7 @@ class LogSink {
   virtual void OnLogMessage(const std::string& msg,
                             LoggingSeverity severity,
                             const char* tag);
+  virtual void OnLogMessage(const std::string& msg, LoggingSeverity severity);
   virtual void OnLogMessage(const std::string& message) = 0;
 };
 


### PR DESCRIPTION
This implements a change in a later release of WebRTC

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/caffeinetv/webrtc/2)
<!-- Reviewable:end -->
